### PR TITLE
Add privateToken to setup on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ import { JunoModule } from 'nestjs-juno';
         endpoint: '',
         clientId: '',
         clientSecret: '',
+        privateToken: '',
     }),
   ],
 })
@@ -65,6 +66,7 @@ export default {
         endpoint: process.env.JUNO_ENDPOINT,
         clientId: process.env.JUNO_CLIENT_ID,
         clientSecret: process.env.JUNO_CLIENT_SECRET,
+        privateToken: process.env.JUNO_PRIVATE_TOKEN,
 };
 ```
 


### PR DESCRIPTION
Ao tentar importar o JunoModule, a opção `privateToken` se mostrou obrigatória, gerando erros na compilação em TypeScript. Este PR adiciona esse parâmetro à documentação da configuração de inicialização do módulo.